### PR TITLE
Add an option to choose the HipChat message color

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ cd amazon-cloudwatch-to-hipchat
 heroku apps:create
 heroku config:set HIPCHAT_API_TOKEN=secret \
                   HIPCHAT_ROOM_ID=12345 \
-                  HIPCHAT_FROM_NAME="AWS CloudWatch"
+                  HIPCHAT_MESSAGE_COLOR="Red" \
+                  HIPCHAT_FROM_NAME="AWS CloudWatch" \
 # Note that your HIPCHAT_FROM_NAME must be no more than 15 characters long: https://www.hipchat.com/docs/api/method/rooms/message
 git push heroku master
 ```

--- a/routes/index.js
+++ b/routes/index.js
@@ -32,6 +32,7 @@ exports.index = function(req, res){
                     'from=' + process.env.HIPCHAT_FROM_NAME + '&' +
                     'message=' + message + '&' +
                     'notify=1&' +
+                    'color=' + process.env.HIPCHAT_MESSAGE_COLOR + '&' +
                     'format=json';
 
         request(hipchatUrl, function (err, result, body) {


### PR DESCRIPTION
The HipChat API allows the message background to be picked as well. 
Might be useful to the ones who get alerted for important AWS events. 

Ignore the PR if you feel the feature is unnecessary. And thank you for building this, works like a charm! 